### PR TITLE
Run the check-links workflow on PR and not just scheduled

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,5 +1,6 @@
 name: Check links in Markdown files
 on:
+  pull_request:
   schedule:
     - cron: "0 0 * * 1" # midnight every Monday
 

--- a/docs/posts/github_environment.md
+++ b/docs/posts/github_environment.md
@@ -13,7 +13,7 @@ tags:
 # Adopting a more rational use of Continuous Integration with GitHub Actions
 
 In the Imperial RSE Team we make extensive use of [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI) with
-[GitHub Actions](https://docs.github.com/en/Actions). We use CI to ensure our projects build and are correct across a range of
+[GitHub Actions](https://docs.github.com/en/actions). We use CI to ensure our projects build and are correct across a range of
 scenarios (OS, python version, dependency version, etc.). Widely accepted wisdom is that
 it is best practice to catch issues early via frequent and thorough CI rather than to
 catch them later. This must however be set against the monetary and environment cost of


### PR DESCRIPTION
This is to prevent bad links from being committed and only being detected later on.