### PR TITLE
CI: Check that blog builds without warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  release:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v3.0.0
+        with:
+          poetry-version: 1.8.3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: poetry
+      - name: Install dependencies
+        run: poetry install
+      - name: Check that documentation builds cleanly with MkDocs
+        run: poetry run mkdocs build -s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Check that documentation builds cleanly with MkDocs
-        run: poetry run mkdocs build -s
+        run: poetry run mkdocs build --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI checks
 
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  release:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Build docs with MkDocs
-        run: poetry run mkdocs build
+        run: poetry run mkdocs build --strict
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
Add a workflow to run MkDocs in strict mode to check for build warnings and errors.

Closes #25.
