### PR TITLE
Fix poetry warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "rseblog"
 version = "0.1.0"
 description = "Blog for Imperial's Central RSE Team"
 authors = ["Your Name <you@example.com>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
It seems that nowadays you have to specify `package-mode = false` if you want to use `poetry` for dependency management but not packaging, otherwise you get a deprecation warning. Let's fix this before it becomes an error.

Fixes #28.
