### PR TITLE
Enable automatic toggle between light and dark theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,24 @@ repo_url: https://github.com/ImperialCollegeLondon/RSEBlog
 theme:
   name: material
   logo: assets/imperial_bw.svg
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
This adds some configuration to switch between light and dark colour schemes based on the selected system setting for the computer.

It is taken directly from the [Material for MkDocs Documentation](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode)