### PR TITLE
Enable latex formatting for rendering maths

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Introduction
 Note: If authors are not already listed in `docs/.authors.yml`, please add them. Similarly, any new `categories` should be listed under `categories_allowed` in `mkdocs.yml`. We should endeavour to keep categories very broad.
 
 - After the introduction paragraph of the blog, include `<!-- more -->`. This will render a shorter version of the blog on the landing page with a `Continue reading` link.
-- Equations and mathematical symbols can be rendered using Latex markup, either in a block enclosed by `$$` delimiters, or inline with `$` delimiters.
 - Preview the blog locally using `mkdocs serve`.
 - Open a `Pull Request` and request for a review.
 
@@ -89,3 +88,10 @@ Refer to the [code blocks documentation](https://squidfunk.github.io/mkdocs-mate
 #### Customising images
 
 Refer to the [Attribute Lists](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists) in the Material Theme docs and [MkDocs Caption](https://tobiasah.github.io/mkdocs-caption/) for customising images in your blog post.
+
+#### Rendering mathematical expressions
+
+You can use LaTeX markup to render mathematical expressions, enabled via [Mathjax](https://www.mathjax.org) and [mdx_math](https://github.com/mitya57/python-markdown-math).
+
+- To write an inline expression, wrap the expression in `$` delimiters.
+- To write the expression as a block, delimit the expression with either `$$` or as a [code block](#code-blocks) with the `math` shortcode.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains blogs by the [central RSE team](https://www.imperial.ac
 
 - Make sure you have [poetry](https://python-poetry.org/docs/#installation) installed.
 - Clone the repository locally (`git clone https://github.com/ImperialCollegeLondon/RSEBlog.git`).
-- Install dependencies `poetry install`
+- Install the dependencies `poetry install`
 - Install the pre-commit hooks `poetry run pre-commit install`
 
 ### Adding your blog
@@ -43,6 +43,7 @@ Introduction
 Note: If authors are not already listed in `docs/.authors.yml`, please add them. Similarly, any new `categories` should be listed under `categories_allowed` in `mkdocs.yml`. We should endeavour to keep categories very broad.
 
 - After the introduction paragraph of the blog, include `<!-- more -->`. This will render a shorter version of the blog on the landing page with a `Continue reading` link.
+- Equations and mathematical symbols can be rendered using Latex markup, either in a block enclosed by `$$` delimiters, or inline with `$` delimiters.
 - Preview the blog locally using `mkdocs serve`.
 - Open a `Pull Request` and request for a review.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,9 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+
 plugins:
   - search
   - tags:
@@ -55,6 +58,8 @@ plugins:
 
 markdown_extensions:
   - admonition
+  - mdx_math:
+      enable_dollar_delimiter: True
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.highlight:

--- a/poetry.lock
+++ b/poetry.lock
@@ -861,6 +861,20 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-markdown-math"
+version = "0.8"
+description = "Math extension for Python-Markdown"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "python-markdown-math-0.8.tar.gz", hash = "sha256:8564212af679fc18d53f38681f16080fcd3d186073f23825c7ce86fadd3e3635"},
+    {file = "python_markdown_math-0.8-py3-none-any.whl", hash = "sha256:c685249d84b5b697e9114d7beb352bd8ca2e07fd268fd4057ffca888c14641e5"},
+]
+
+[package.dependencies]
+Markdown = ">=3.0"
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -1160,4 +1174,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "df73ffab3e5da85ad6bb3badfca386f977ed1ef15020838297fb22ac700ebe90"
+content-hash = "b60341f49907ba1b8228e806240a1ccaeaf53e59700007bdccaebf0cb3ac20c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ mkdocs = "^1.6.0"
 mkdocs-material = "^9.5.27"
 pre-commit = "^3.7.1"
 mkdocs-caption = "^1.2.0"
+python-markdown-math = "^0.8"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^3.7.1"


### PR DESCRIPTION
This PR adds the required package and config to render latex-formatted maths in mkdocs.

Changes:
- Add python-markdown-math package
- Add mathjax javascript
- Add mdx_math markdown extension

Closes #24 