### PR TITLE
Tweaks to `markdownlint` configuration

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+# For list of rules, see: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md
+MD013: false
+MD041: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
 # For list of rules, see: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md
+
+# Line length
 MD013: false
-MD041: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,5 +8,5 @@ repos:
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.41.0
     hooks:
-      - id: markdownlint
+      - id: markdownlint-fix
         args: ["--disable", "MD013", "MD041", "--"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,3 @@ repos:
     rev: v0.41.0
     hooks:
       - id: markdownlint-fix
-        args: ["--disable", "MD013", "MD041", "--"]


### PR DESCRIPTION
@HarmonicReflux's PR is currently being blocked by various CI failures, including some `markdownlint` errors.

Many of these can be auto-fixed by `markdownlint` if you use the `markdownlint-fix` hook instead. Let's just make our lives easier and take auto-fixes where we can get them!

I also made a couple of other small changes:

- I changed from disabling `markdownlint` checks with the `args` property in `.pre-commit.config.yaml` to using a separate `.markdownlint.yaml` file
- I re-enabled [MD041](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md041---first-line-in-file-should-be-a-top-level-header); none of our posts violate this rule anyway