### PR TITLE
Fix dead link in RSECon 2022 post

### DIFF
--- a/docs/posts/20220927_rsecon_2022.md
+++ b/docs/posts/20220927_rsecon_2022.md
@@ -57,7 +57,7 @@ Machine Learning (ML) is used more widely than ever across almost all spheres of
 
 ### Mental health
 
-[Dave Horsfall](https://www.software.ac.uk/fellowship-programme/dave-horsfall) from Newcastle University gave a super plenary talk focused on mental health for RSEs and how we can create a judgement-free environment where topics around mental health and wellbeing can be discussed. Dave is a Software Sustainability Institute Fellow and advocates for better mental health in the RSE community. The presentation was highly interactive and insightful. We would encourage any RSEs who have not already done so to fill out [Dave’s short survey](https://softwaresaved.limequery.com/837235) that aims to capture a snapshot of mental health within the UK community.
+[Dave Horsfall](https://www.software.ac.uk/fellowship-programme/dave-horsfall) from Newcastle University gave a super plenary talk focused on mental health for RSEs and how we can create a judgement-free environment where topics around mental health and wellbeing can be discussed. Dave is a Software Sustainability Institute Fellow and advocates for better mental health in the RSE community. The presentation was highly interactive and insightful. ~~We would encourage any RSEs who have not already done so to fill out Dave’s short survey that aims to capture a snapshot of mental health within the UK community~~ [edit: survey is now closed].
 
 ### Quarto
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ markdown_extensions:
   - admonition
   - mdx_math:
       enable_dollar_delimiter: True
+  - pymdownx.tilde
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.highlight:


### PR DESCRIPTION
One of the links in an old post is now dead. I've removed the link and crossed out the text (which required the `pymdown-tilde` extension).

Fixes #70.