### PR TITLE
Follow PEP8 standard on library imports. `import` has higher `precede…

### DIFF
--- a/docs/posts/20241031_design_patterns_2024.md
+++ b/docs/posts/20241031_design_patterns_2024.md
@@ -286,9 +286,9 @@ Translating the UML diagram to Python code then looks as follows:
 
 ```python
 from dataclasses import dataclass
-import numpy as np
 from scipy.stats import norm
 from typing import Callable, Tuple
+import numpy as np
 
 
 OptionPriceStrategy = Callable[['BlackScholesOption'], float]  # define the OptionPriceStrategy type as a Callable that accepts a BlackScholesOption and returns a float


### PR DESCRIPTION
For the pedantic and the ones who follow PEP8.

I modified the top-level import statements for the section containing the Python code.