### PR TITLE
Tweaks to link checker

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,8 +1,11 @@
 name: Check links in Markdown files
 on:
-  pull_request:
   schedule:
     - cron: "0 0 * * 1" # midnight every Monday
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   check-links:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-links:
     name: Linkspector
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run linkspector


### PR DESCRIPTION
I noticed we're only running the workflow for PRs and as a cron job, but it makes sense to also run it on pushes to `main` and on `workflow_dispatch`, so we can manually trigger it.

An upstream bug has been fixed, so we can now use the `ubuntu-latest` runner.